### PR TITLE
Fix filtering 

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -391,9 +391,12 @@ async def get_accounts(
     allowed=True,
     blocked=False,
 ) -> List[NostrAccount]:
+
+    if not allowed and not blocked:
+        return []
+        
     rows = await db.fetchall(
-        "SELECT * FROM nostrrelay.accounts WHERE relay_id = ? AND allowed = ? AND blocked = ?",
+        "SELECT * FROM nostrrelay.accounts WHERE relay_id = ? AND allowed = ? OR blocked = ?",
         (relay_id, allowed, blocked),
     )
-
     return [NostrAccount.from_row(row) for row in rows]

--- a/static/components/relay-details/relay-details.html
+++ b/static/components/relay-details/relay-details.html
@@ -609,7 +609,6 @@
               row-key="pubkey"
               :columns="accountsTable.columns"
               :pagination.sync="accountsTable.pagination"
-              :filter="accountsFilter"
             >
               <template v-slot:body="props">
                 <q-tr :props="props">

--- a/static/components/relay-details/relay-details.js
+++ b/static/components/relay-details/relay-details.js
@@ -18,7 +18,6 @@ async function relayDetails(path) {
             description: ''
           }
         },
-        accountsFilter: '',
         showBlockedAccounts: true,
         showAllowedAccounts: false,
         accountsTable: {

--- a/views_api.py
+++ b/views_api.py
@@ -195,6 +195,7 @@ async def api_create_or_update_account(
 
     try:
         data.pubkey = normalize_public_key(data.pubkey)
+        
         account = await get_account(data.relay_id, data.pubkey)
         if not account:
             account = NostrAccount(
@@ -208,7 +209,7 @@ async def api_create_or_update_account(
             account.blocked = data.blocked
         if data.allowed is not None:
             account.allowed = data.allowed
-
+        
         return await update_account(data.relay_id, account)
 
     except ValueError as ex:
@@ -256,8 +257,8 @@ async def api_delete_account(
 @nostrrelay_ext.get("/api/v1/account")
 async def api_get_accounts(
     relay_id: str,
-    allowed=False,
-    blocked=True,
+    allowed: bool = False,
+    blocked: bool = True,
     wallet: WalletTypeInfo = Depends(require_invoice_key),
 ) -> List[NostrAccount]:
     try:


### PR DESCRIPTION
Instead of asking the DB for the accounts, we now call it once and filter client side! Filtering now works as expected.

@motorina0 , when toggling, in the account row, shouldn't the toggles be allowed OR blocked? and never the two at the same time? or is it that a user can be blocked for some time, if the OP whiches? If the later, PR is ready, if not I'll fix it also.

Closes #8 